### PR TITLE
Fix issue #15

### DIFF
--- a/scripts/build.py
+++ b/scripts/build.py
@@ -3,7 +3,7 @@ from typing import List
 import shutil
 from pathlib import Path
 
-PROJECT_ROOT = Path(__file__).parent.parent.absolute()
+PROJECT_ROOT = Path(__file__).absolute().parent.parent
 OUTPUT = PROJECT_ROOT.joinpath("build")
 
 


### PR DESCRIPTION
Python 3.6 and Python 3.9 have different values for the `__file__`.
When running from inside the `scripts` folder, in 3.6 the value will be
`build.py` while in 3.9 the value will be an absolute path. That means
in 3.6 accessing the `parent`s will not work.
Creating an absolute path first fixes the difference.

Closes #15 